### PR TITLE
Refactor:#69 fetch searchMovie url 변경 및 카드 컴포넌트 수정

### DIFF
--- a/src/components/commons/MovieCard.tsx
+++ b/src/components/commons/MovieCard.tsx
@@ -6,10 +6,10 @@ import { formatDateSimple } from '@/utils/formatFunction';
 import { TMDB_IMG_URL } from '@/constants/tmdbBaseUrl';
 import { DetailMovie } from '@/types/DetailMovie';
 import { Movie } from '@/types/Movie';
+import noImg from '@images/images/noImage.png';
 
 type MovieCardProps = {
   movie: DetailMovie | Movie;
-  // my-page > fetchBookmarkedMovies 함수 부분에서 getMovieDetails 함수를 사용하여 유저의 북마크 목록을 뿌려줘야 하는데, MovieCard 컴포넌트와 getMovieDetails 함수에서 타입 오류로 인해 유니온 타입을 사용함
 };
 
 const MovieCard = ({ movie }: MovieCardProps) => {
@@ -18,13 +18,16 @@ const MovieCard = ({ movie }: MovieCardProps) => {
   // yyyy년 m월 d일 형식의 날짜 포멧팅
   const formattedDate = formatDateSimple(movie.release_date);
 
+  // poster_path가 유효하지 않으면 noimage.png 사용
+  const posterSrc = movie.poster_path ? `${TMDB_IMG_URL}/t/p/w300${movie.poster_path}` : noImg;
+
   return (
     <Card>
       {/* 상세페이지로 이동 */}
       <Link href={`/detail/${movie.id}`}>
         <div className='relative aspect-[2/3] cursor-pointer'>
           <Image
-            src={`${TMDB_IMG_URL}/t/p/w300${movie.poster_path}`}
+            src={posterSrc}
             alt={movie.title}
             fill
             sizes='(max-width: 640px) 100vw, 20vw'

--- a/src/services/searchMovie.ts
+++ b/src/services/searchMovie.ts
@@ -6,7 +6,7 @@ const BASE_NUMBER = 0;
 
 // 검색어와 페이지 값 받아서 라우트 핸들러로 전달
 export const fetchSearchMovies = async ({ input, page = PARAM_NUMBER }: { input: string; page: number }) => {
-  const URL = `http://localhost:3000/api/search?title=${input}&page=${page}`; //TODO 배포 후 환경변수로 뺄 것
+  const URL = `/api/search?title=${input}&page=${page}`;
   const res = await fetch(URL);
   const data: PaginatedResponse<Movie> = await res.json();
   return data;


### PR DESCRIPTION
## :bulb: 관련이슈
> #69 
## :four_leaf_clover: 작업 요약
- searchMovie를 fetch할 때 들어가는 url이 수정되었습니다
- 영화 사진이 없을 때 noImg를 렌더링하도록 공통 카드 컴포넌트가 수정되었습니다
<img width="1161" alt="Screenshot 2025-03-27 at 4 10 45 AM" src="https://github.com/user-attachments/assets/5ec06188-91cd-4c61-b816-ea07287bfcc5" />

